### PR TITLE
Expand tilde and environment variables in path field

### DIFF
--- a/sample.toml
+++ b/sample.toml
@@ -26,4 +26,4 @@ database = "dvdrental"
 
 [[conn]]
 type = "sqlite"
-path = "/Users/tako8ki/Downloads/chinook.db"
+path = "$HOME/Downloads/chinook.db"

--- a/src/config.rs
+++ b/src/config.rs
@@ -333,28 +333,28 @@ mod test {
 
     #[test]
     #[cfg(windows)]
-    fn test_expand_path() {
+    fn test_expand_patha() {
         let home = std::env::var("APPDATA").unwrap();
         let test_env = "baz";
         env::set_var("TEST", test_env);
 
         assert_eq!(
-            expand_path(Path::new("%APPDATA%/foo").to_path_buf()),
-            Some(PathBuf::from(home).join("foo"))
-        );
-
-        assert_eq!(
-            expand_path(Path::new("%APPDATA%/foo/%TEST%/bar").to_path_buf()),
-            Some(PathBuf::from(&home).join("foo").join(test_env).join("bar"))
-        );
-
-        assert_eq!(
-            expand_path(Path::new("~/foo").to_path_buf()),
+            expand_path(&Path::new("%APPDATA%/foo")),
             Some(PathBuf::from(&home).join("foo"))
         );
 
         assert_eq!(
-            expand_path(Path::new("~/foo/~/bar").to_path_buf()),
+            expand_path(&Path::new("%APPDATA%/foo/%TEST%/bar")),
+            Some(PathBuf::from(&home).join("foo").join(test_env).join("bar"))
+        );
+
+        assert_eq!(
+            expand_path(&Path::new("~/foo")),
+            Some(PathBuf::from(&home).join("foo"))
+        );
+
+        assert_eq!(
+            expand_path(&Path::new("~/foo/~/bar")),
             Some(PathBuf::from(&home).join("foo").join("~").join("bar"))
         );
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -350,12 +350,17 @@ mod test {
 
         assert_eq!(
             expand_path(&Path::new("~/foo")),
-            Some(PathBuf::from(&home).join("foo"))
+            Some(PathBuf::from(&dirs_next::home_dir().unwrap()).join("foo"))
         );
 
         assert_eq!(
             expand_path(&Path::new("~/foo/~/bar")),
-            Some(PathBuf::from(&home).join("foo").join("~").join("bar"))
+            Some(
+                PathBuf::from(&dirs_next::home_dir().unwrap())
+                    .join("foo")
+                    .join("~")
+                    .join("bar")
+            )
         );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -303,7 +303,7 @@ mod test {
         let home = std::env::var("HOME").unwrap();
         #[cfg(windows)]
         let home = std::env::var("APPDATA").unwrap();
-        let projects = PathBuf::from(format!("{}/Projects", home));
+        let projects = PathBuf::from(home).join("Projects");
         assert_eq!(expand_tilde("~/Projects"), Some(projects));
         assert_eq!(expand_tilde("/foo/bar"), Some("/foo/bar".into()));
         assert_eq!(

--- a/src/config.rs
+++ b/src/config.rs
@@ -288,7 +288,7 @@ fn expand_path(path: &Path) -> Option<PathBuf> {
         let path = path.to_str()?;
         expanded_path = if cfg!(unix) && path.starts_with('$') {
             expanded_path.join(std::env::var(path.strip_prefix('$')?).unwrap_or_default())
-        } else if cfg!(winddows) && path.starts_with('%') && path.ends_with('%') {
+        } else if cfg!(windows) && path.starts_with('%') && path.ends_with('%') {
             expanded_path
                 .join(std::env::var(path.strip_prefix('%')?.strip_suffix('%')?).unwrap_or_default())
         } else {

--- a/src/config.rs
+++ b/src/config.rs
@@ -334,17 +334,17 @@ mod test {
     #[test]
     #[cfg(windows)]
     fn test_expand_patha() {
-        let home = std::env::var("APPDATA").unwrap();
+        let home = std::env::var("HOMEPATH").unwrap();
         let test_env = "baz";
         env::set_var("TEST", test_env);
 
         assert_eq!(
-            expand_path(&Path::new("%APPDATA%/foo")),
+            expand_path(&Path::new("%HOMEPATH%/foo")),
             Some(PathBuf::from(&home).join("foo"))
         );
 
         assert_eq!(
-            expand_path(&Path::new("%APPDATA%/foo/%TEST%/bar")),
+            expand_path(&Path::new("%HOMEPATH%/foo/%TEST%/bar")),
             Some(PathBuf::from(&home).join("foo").join(test_env).join("bar"))
         );
 


### PR DESCRIPTION
closes #104 

```toml
[[conn]]
type = "sqlite"
path = "$HOME/Downloads/chinook.db"

[[conn]]
type = "sqlite"
path = "~/Downloads/chinook.db"
```