### PR TITLE
Fix tiny bug in checking whether a SQL statement is a SELECT statement or not

### DIFF
--- a/src/database/mysql.rs
+++ b/src/database/mysql.rs
@@ -149,7 +149,7 @@ impl Pool for MySqlPool {
     async fn execute(&self, query: &String) -> anyhow::Result<ExecuteResult> {
         let query = query.trim();
 
-        if query.starts_with("SELECT") || query.starts_with("select") {
+        if query.to_uppercase().starts_with("SELECT") {
             let mut rows = sqlx::query(query).fetch(&self.pool);
             let mut headers = vec![];
             let mut records = vec![];

--- a/src/database/postgres.rs
+++ b/src/database/postgres.rs
@@ -149,7 +149,7 @@ impl TableRow for Index {
 impl Pool for PostgresPool {
     async fn execute(&self, query: &String) -> anyhow::Result<ExecuteResult> {
         let query = query.trim();
-        if query.starts_with("SELECT") || query.starts_with("select") {
+        if query.to_uppercase().starts_with("SELECT") {
             let mut rows = sqlx::query(query).fetch(&self.pool);
             let mut headers = vec![];
             let mut records = vec![];

--- a/src/database/sqlite.rs
+++ b/src/database/sqlite.rs
@@ -152,7 +152,7 @@ impl TableRow for Index {
 impl Pool for SqlitePool {
     async fn execute(&self, query: &String) -> anyhow::Result<ExecuteResult> {
         let query = query.trim();
-        if query.starts_with("SELECT") || query.starts_with("select") {
+        if query.to_uppercase().starts_with("SELECT") {
             let mut rows = sqlx::query(query).fetch(&self.pool);
             let mut headers = vec![];
             let mut records = vec![];


### PR DESCRIPTION
changelog: none

In checking whether a SQL statement is a SELECT statement or not, Only cases beginning with `SELECT` or `select` were considered to be SELECT statements, so we changed the check to be case-insensitive.
