### PR TITLE
Fix JSON conversion of the table name which is also a keyword for PostgreSQL

### DIFF
--- a/src/database/postgres.rs
+++ b/src/database/postgres.rs
@@ -482,7 +482,7 @@ impl PostgresPool {
     ) -> anyhow::Result<Vec<serde_json::Value>> {
         let query = if let Some(filter) = filter {
             format!(
-                r#"SELECT to_json({table}.*) FROM "{database}"."{table_schema}"."{table}" WHERE {filter} LIMIT {limit} OFFSET {page}"#,
+                r#"SELECT to_json("{table}".*) FROM "{database}"."{table_schema}"."{table}" WHERE {filter} LIMIT {limit} OFFSET {page}"#,
                 database = database.name,
                 table = table.name,
                 filter = filter,
@@ -492,7 +492,7 @@ impl PostgresPool {
             )
         } else {
             format!(
-                r#"SELECT to_json({table}.*) FROM "{database}"."{table_schema}"."{table}" LIMIT {limit} OFFSET {page}"#,
+                r#"SELECT to_json("{table}".*) FROM "{database}"."{table_schema}"."{table}" LIMIT {limit} OFFSET {page}"#,
                 database = database.name,
                 table = table.name,
                 table_schema = table.schema.clone().unwrap_or_else(|| "public".to_string()),


### PR DESCRIPTION
Hi all :wave:
Similarly to escape the table name in the SELECT command query, here we
escape the table name with apostrophes.
In fact, `to_json()` raised a "Syntax error" for table that uses a keyword as
its name.

An example is a table named `order`.
