### PR TITLE
Adding help and README for exit pop up key

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ If you want to add connections, you need to edit your config file. For more info
 | <kbd>/</kbd> | Filter |
 | <kbd>?</kbd> | Help |
 | <kbd>1</kbd>, <kbd>2</kbd>, <kbd>3</kbd>, <kbd>4</kbd>, <kbd>5</kbd> | Switch to records/columns/constraints/foreign keys/indexes tab |
+| <kbd>Esc</kbd> | Hide pop up |
 
 ## Configuration
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -113,6 +113,7 @@ impl App {
 
     fn commands(&self) -> Vec<CommandInfo> {
         let mut res = vec![
+            CommandInfo::new(command::exit_pop_up(&self.config.key_config)),
             CommandInfo::new(command::filter(&self.config.key_config)),
             CommandInfo::new(command::help(&self.config.key_config)),
             CommandInfo::new(command::toggle_tabs(&self.config.key_config)),

--- a/src/components/command.rs
+++ b/src/components/command.rs
@@ -172,3 +172,10 @@ pub fn help(key_config: &KeyConfig) -> CommandText {
         CMD_GROUP_GENERAL,
     )
 }
+
+pub fn exit_pop_up(key_config: &KeyConfig) -> CommandText {
+    CommandText::new(
+        format!("Exit pop up [{}]", key_config.exit_popup),
+        CMD_GROUP_GENERAL,
+    )
+}


### PR DESCRIPTION
This PR adds a description for exit pop up.

I noticed that the key to close the popup (<kbd>Esc</kbd>) exists but is not in the help.

Thank you in advance.

changelog: Adding help for `exit pop up`.
