### PR TITLE
Add more cursor movements

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -172,10 +172,10 @@ impl App {
                     &database,
                     &table,
                     0,
-                    if self.record_table.filter.input_str().is_empty() {
+                    if self.record_table.filter.input.value_str().is_empty() {
                         None
                     } else {
-                        Some(self.record_table.filter.input_str())
+                        Some(self.record_table.filter.input.value_str())
                     },
                 )
                 .await?;
@@ -278,10 +278,11 @@ impl App {
                                             &database,
                                             &table,
                                             index as u16,
-                                            if self.record_table.filter.input_str().is_empty() {
+                                            if self.record_table.filter.input.value_str().is_empty()
+                                            {
                                                 None
                                             } else {
-                                                Some(self.record_table.filter.input_str())
+                                                Some(self.record_table.filter.input.value_str())
                                             },
                                         )
                                         .await?;

--- a/src/components/database_filter.rs
+++ b/src/components/database_filter.rs
@@ -1,5 +1,6 @@
-use super::{compute_character_width, Component, DrawableComponent, EventState};
+use super::{Component, DrawableComponent, EventState};
 use crate::components::command::CommandInfo;
+use crate::components::utils::input::Input;
 use crate::event::Key;
 use anyhow::Result;
 use database_tree::Table;
@@ -11,34 +12,23 @@ use tui::{
     widgets::{Block, Borders, Paragraph},
     Frame,
 };
-use unicode_width::UnicodeWidthStr;
 
 pub struct DatabaseFilterComponent {
     pub table: Option<Table>,
-    input: Vec<char>,
-    input_idx: usize,
-    input_cursor_position: u16,
+    pub input: Input,
 }
 
 impl DatabaseFilterComponent {
     pub fn new() -> Self {
         Self {
             table: None,
-            input: Vec::new(),
-            input_idx: 0,
-            input_cursor_position: 0,
+            input: Input::new(),
         }
-    }
-
-    pub fn input_str(&self) -> String {
-        self.input.iter().collect()
     }
 
     pub fn reset(&mut self) {
         self.table = None;
-        self.input = Vec::new();
-        self.input_idx = 0;
-        self.input_cursor_position = 0;
+        self.input.reset();
     }
 }
 
@@ -46,10 +36,10 @@ impl DrawableComponent for DatabaseFilterComponent {
     fn draw<B: Backend>(&self, f: &mut Frame<B>, area: Rect, focused: bool) -> Result<()> {
         let query = Paragraph::new(Spans::from(format!(
             "{:w$}",
-            if self.input.is_empty() && !focused {
+            if self.input.value.is_empty() && !focused {
                 "Filter tables".to_string()
             } else {
-                self.input_str()
+                self.input.value_str()
             },
             w = area.width as usize
         )))
@@ -63,7 +53,7 @@ impl DrawableComponent for DatabaseFilterComponent {
 
         if focused {
             f.set_cursor(
-                (area.x + self.input_cursor_position).min(area.right().saturating_sub(1)),
+                (area.x + self.input.cursor_position).min(area.right().saturating_sub(1)),
                 area.y,
             )
         }
@@ -75,58 +65,9 @@ impl Component for DatabaseFilterComponent {
     fn commands(&self, _out: &mut Vec<CommandInfo>) {}
 
     fn event(&mut self, key: Key) -> Result<EventState> {
-        let input_str: String = self.input.iter().collect();
-
-        match key {
-            Key::Char(c) => {
-                self.input.insert(self.input_idx, c);
-                self.input_idx += 1;
-                self.input_cursor_position += compute_character_width(c);
-
-                return Ok(EventState::Consumed);
-            }
-            Key::Delete | Key::Backspace => {
-                if input_str.width() > 0 && !self.input.is_empty() && self.input_idx > 0 {
-                    let last_c = self.input.remove(self.input_idx - 1);
-                    self.input_idx -= 1;
-                    self.input_cursor_position -= compute_character_width(last_c);
-                }
-                return Ok(EventState::Consumed);
-            }
-            Key::Left => {
-                if !self.input.is_empty() && self.input_idx > 0 {
-                    self.input_idx -= 1;
-                    self.input_cursor_position = self
-                        .input_cursor_position
-                        .saturating_sub(compute_character_width(self.input[self.input_idx]));
-                }
-                return Ok(EventState::Consumed);
-            }
-            Key::Ctrl('a') => {
-                if !self.input.is_empty() && self.input_idx > 0 {
-                    self.input_idx = 0;
-                    self.input_cursor_position = 0
-                }
-                return Ok(EventState::Consumed);
-            }
-            Key::Right => {
-                if self.input_idx < self.input.len() {
-                    let next_c = self.input[self.input_idx];
-                    self.input_idx += 1;
-                    self.input_cursor_position += compute_character_width(next_c);
-                }
-                return Ok(EventState::Consumed);
-            }
-            Key::Ctrl('e') => {
-                if self.input_idx < self.input.len() {
-                    self.input_idx = self.input.len();
-                    self.input_cursor_position = self.input_str().width() as u16;
-                }
-                return Ok(EventState::Consumed);
-            }
-            _ => (),
+        match self.input.handle_key(key) {
+            (Some(_), _) => Ok(EventState::Consumed),
+            _ => Ok(EventState::NotConsumed),
         }
-
-        Ok(EventState::NotConsumed)
     }
 }

--- a/src/components/databases.rs
+++ b/src/components/databases.rs
@@ -190,10 +190,10 @@ impl DatabasesComponent {
                     item.clone(),
                     selected,
                     area.width,
-                    if self.filter.input_str().is_empty() {
+                    if self.filter.input.value_str().is_empty() {
                         None
                     } else {
-                        Some(self.filter.input_str())
+                        Some(self.filter.input.value_str())
                     },
                 )
             });
@@ -229,10 +229,10 @@ impl Component for DatabasesComponent {
         }
 
         if matches!(self.focus, Focus::Filter) {
-            self.filterd_tree = if self.filter.input_str().is_empty() {
+            self.filterd_tree = if self.filter.input.value_str().is_empty() {
                 None
             } else {
-                Some(self.tree.filter(self.filter.input_str()))
+                Some(self.tree.filter(self.filter.input.value_str()))
             };
         }
 

--- a/src/components/utils/input.rs
+++ b/src/components/utils/input.rs
@@ -86,3 +86,99 @@ impl Input {
         }
     }
 }
+
+#[cfg(test)]
+
+mod test {
+    use super::Input;
+    use crate::components::compute_character_width;
+    use crate::event::Key;
+    use unicode_width::UnicodeWidthStr;
+
+    #[test]
+    fn test_adds_new_chars_for_char_key() {
+        let mut input = Input::new();
+        input.handle_key(Key::Char('a'));
+
+        assert_eq!(input.value, vec!['a']);
+        assert_eq!(input.cursor_index, 1);
+        assert_eq!(input.cursor_position, compute_character_width('a'));
+    }
+
+    #[test]
+    fn test_deletes_chars_for_backspace_and_delete_key() {
+        let mut input = Input::new();
+        input.value = vec!['a', 'b'];
+        input.cursor_index = 2;
+        input.cursor_position = input.value_str().width() as u16;
+
+        input.handle_key(Key::Delete);
+        input.handle_key(Key::Backspace);
+
+        assert_eq!(input.value, Vec::<char>::new());
+        assert_eq!(input.cursor_index, 0);
+        assert_eq!(input.cursor_position, 0);
+    }
+
+    #[test]
+    fn test_moves_cursor_left_for_left_key() {
+        let mut input = Input::new();
+        input.value = vec!['a'];
+        input.cursor_index = 1;
+        input.cursor_position = compute_character_width('a');
+
+        let (matched_key, input_changed) = input.handle_key(Key::Left);
+
+        assert_eq!(matched_key, Some(Key::Left));
+        assert_eq!(input_changed, true);
+        assert_eq!(input.value, vec!['a']);
+        assert_eq!(input.cursor_index, 0);
+        assert_eq!(input.cursor_position, 0);
+    }
+
+    #[test]
+    fn test_moves_cursor_right_for_right_key() {
+        let mut input = Input::new();
+        input.value = vec!['a'];
+
+        let (matched_key, input_changed) = input.handle_key(Key::Right);
+
+        assert_eq!(matched_key, Some(Key::Right));
+        assert_eq!(input_changed, true);
+        assert_eq!(input.value, vec!['a']);
+        assert_eq!(input.cursor_index, 1);
+        assert_eq!(input.cursor_position, compute_character_width('a'));
+    }
+
+    #[test]
+    fn test_jumps_to_beginning_for_ctrl_a() {
+        let mut input = Input::new();
+        input.value = vec!['a', 'b', 'c'];
+        input.cursor_index = 3;
+        input.cursor_position = input.value_str().width() as u16;
+
+        let (matched_key, input_changed) = input.handle_key(Key::Ctrl('a'));
+
+        assert_eq!(matched_key, Some(Key::Ctrl('a')));
+        assert_eq!(input_changed, true);
+        assert_eq!(input.value, vec!['a', 'b', 'c']);
+        assert_eq!(input.cursor_index, 0);
+        assert_eq!(input.cursor_position, 0);
+    }
+
+    #[test]
+    fn test_jumps_to_end_for_ctrl_e() {
+        let mut input = Input::new();
+        input.value = vec!['a', 'b', 'c'];
+        input.cursor_index = 0;
+        input.cursor_position = 0;
+
+        let (matched_key, input_changed) = input.handle_key(Key::Ctrl('e'));
+
+        assert_eq!(matched_key, Some(Key::Ctrl('e')));
+        assert_eq!(input_changed, true);
+        assert_eq!(input.value, vec!['a', 'b', 'c']);
+        assert_eq!(input.cursor_index, 3);
+        assert_eq!(input.cursor_position, input.value_str().width() as u16);
+    }
+}

--- a/src/components/utils/input.rs
+++ b/src/components/utils/input.rs
@@ -39,48 +39,53 @@ impl Input {
                 return (Some(key), true);
             }
             Key::Delete | Key::Backspace => {
-                if value_str.width() > 0 && !self.value.is_empty() && self.cursor_index > 0 {
-                    let last_c = self.value.remove(self.cursor_index - 1);
-                    self.cursor_index -= 1;
-                    self.cursor_position -= compute_character_width(last_c);
-                    return (Some(key), true);
+                if value_str.width() == 0 || self.value.is_empty() || self.cursor_index == 0 {
+                    return (Some(key), false);
                 }
-                return (Some(key), false);
+
+                let last_c = self.value.remove(self.cursor_index - 1);
+                self.cursor_index -= 1;
+                self.cursor_position -= compute_character_width(last_c);
+                return (Some(key), true);
             }
             Key::Left => {
-                if !self.value.is_empty() && self.cursor_index > 0 {
-                    self.cursor_index -= 1;
-                    self.cursor_position = self
-                        .cursor_position
-                        .saturating_sub(compute_character_width(self.value[self.cursor_index]));
-                    return (Some(key), true);
+                if self.value.is_empty() || self.cursor_index == 0 {
+                    return (Some(key), false);
                 }
-                return (Some(key), false);
+
+                self.cursor_index -= 1;
+                self.cursor_position = self
+                    .cursor_position
+                    .saturating_sub(compute_character_width(self.value[self.cursor_index]));
+                return (Some(key), true);
             }
             Key::Right => {
-                if self.cursor_index < self.value.len() {
-                    let next_c = self.value[self.cursor_index];
-                    self.cursor_index += 1;
-                    self.cursor_position += compute_character_width(next_c);
-                    return (Some(key), true);
+                if self.cursor_index == self.value.len() {
+                    return (Some(key), false);
                 }
-                return (Some(key), false);
+
+                let next_c = self.value[self.cursor_index];
+                self.cursor_index += 1;
+                self.cursor_position += compute_character_width(next_c);
+                return (Some(key), true);
             }
             Key::Ctrl('a') => {
-                if !self.value.is_empty() && self.cursor_index > 0 {
-                    self.cursor_index = 0;
-                    self.cursor_position = 0;
-                    return (Some(key), true);
+                if self.value.is_empty() || self.cursor_index == 0 {
+                    return (Some(key), false);
                 }
-                return (Some(key), false);
+
+                self.cursor_index = 0;
+                self.cursor_position = 0;
+                return (Some(key), true);
             }
             Key::Ctrl('e') => {
-                if self.cursor_index < self.value.len() {
-                    self.cursor_index = self.value.len();
-                    self.cursor_position = self.value_str().width() as u16;
-                    return (Some(key), true);
+                if self.cursor_index == self.value.len() {
+                    return (Some(key), false);
                 }
-                return (Some(key), false);
+
+                self.cursor_index = self.value.len();
+                self.cursor_position = self.value_str().width() as u16;
+                return (Some(key), true);
             }
             _ => (None, false),
         }

--- a/src/components/utils/input.rs
+++ b/src/components/utils/input.rs
@@ -1,0 +1,88 @@
+use crate::components::compute_character_width;
+use crate::event::Key;
+use unicode_width::UnicodeWidthStr;
+
+pub struct Input {
+    pub value: Vec<char>,
+    pub cursor_position: u16,
+    pub cursor_index: usize,
+}
+
+impl Input {
+    pub fn new() -> Self {
+        Self {
+            value: Vec::new(),
+            cursor_index: 0,
+            cursor_position: 0,
+        }
+    }
+
+    pub fn value_str(&self) -> String {
+        self.value.iter().collect()
+    }
+
+    pub fn reset(&mut self) {
+        self.value = Vec::new();
+        self.cursor_index = 0;
+        self.cursor_position = 0;
+    }
+
+    pub fn handle_key(&mut self, key: Key) -> (Option<Key>, bool) {
+        let value_str: String = self.value.iter().collect();
+
+        match key {
+            Key::Char(c) => {
+                self.value.insert(self.cursor_index, c);
+                self.cursor_index += 1;
+                self.cursor_position += compute_character_width(c);
+
+                return (Some(key), true);
+            }
+            Key::Delete | Key::Backspace => {
+                if value_str.width() > 0 && !self.value.is_empty() && self.cursor_index > 0 {
+                    let last_c = self.value.remove(self.cursor_index - 1);
+                    self.cursor_index -= 1;
+                    self.cursor_position -= compute_character_width(last_c);
+                    return (Some(key), true);
+                }
+                return (Some(key), false);
+            }
+            Key::Left => {
+                if !self.value.is_empty() && self.cursor_index > 0 {
+                    self.cursor_index -= 1;
+                    self.cursor_position = self
+                        .cursor_position
+                        .saturating_sub(compute_character_width(self.value[self.cursor_index]));
+                    return (Some(key), true);
+                }
+                return (Some(key), false);
+            }
+            Key::Right => {
+                if self.cursor_index < self.value.len() {
+                    let next_c = self.value[self.cursor_index];
+                    self.cursor_index += 1;
+                    self.cursor_position += compute_character_width(next_c);
+                    return (Some(key), true);
+                }
+                return (Some(key), false);
+            }
+            Key::Ctrl('a') => {
+                if !self.value.is_empty() && self.cursor_index > 0 {
+                    self.cursor_index = 0;
+                    self.cursor_position = 0;
+                    return (Some(key), true);
+                }
+                return (Some(key), false);
+            }
+            Key::Ctrl('e') => {
+                if self.cursor_index < self.value.len() {
+                    self.cursor_index = self.value.len();
+                    self.cursor_position = self.value_str().width() as u16;
+                    return (Some(key), true);
+                }
+                return (Some(key), false);
+            }
+            _ => (None, false),
+        }
+    }
+}

--- a/src/components/utils/input.rs
+++ b/src/components/utils/input.rs
@@ -31,12 +31,13 @@ impl Input {
         self.cursor_position = 0;
     }
 
-    fn find_whitespace_backwards(&self) -> Option<usize> {
-        let mut result = None;
 
-        for i in (0..self.cursor_index).rev() {
-            if (i < self.cursor_index - 1) && self.value[i].is_whitespace() {
-                result = Some(i);
+    fn cursor_index_backwards_to_whitespace(&self) -> usize {
+        let mut result = 0;
+
+        for i in (0..self.cursor_index - 1).rev() {
+            if self.value[i].is_whitespace() {
+                result = i + 1;
                 break;
             }
         }
@@ -109,11 +110,7 @@ impl Input {
                     return (Some(key), false);
                 }
 
-                let new_cursor_index = match self.find_whitespace_backwards() {
-                    Some(i) => i + 1,
-                    None => 0,
-                };
-
+                let new_cursor_index = self.cursor_index_backwards_to_whitespace();
                 let mut tail = self.value.to_vec().drain(self.cursor_index..).collect();
 
                 self.cursor_index = new_cursor_index;

--- a/src/components/utils/mod.rs
+++ b/src/components/utils/mod.rs
@@ -1,1 +1,2 @@
+pub mod input;
 pub mod scroll_vertical;


### PR DESCRIPTION
Hey,

thanks for creating this app, I like it a lot! I thought it might make sense to provide more cursor movement / input editing keybindings. To start with <kbd>Ctrl-w</kbd> (word deletion) seemed useful to me in order to delete i.e. a database filter query quickly.

Following changes are included in this PR so far:

- [x] Refactor logic for keyboard input into a separate util struct
- [x] Add tests for existing cursor movement functions
- [x] Add <kbd>Ctrl-w</kbd> as a keybinding to delete words
- [ ] Add more keybindings (<kbd>Alt-f</kbd>, <kbd>Alt-b</kbd> etc.)

If you think this is going in the right direction, I would like to add more keybindings (see list above).
Any feedback (especially concerning the refactoring) very welcome, as I am not super proficient writing Rust so far.

sebashwa