### PR TITLE
Document `name` config field

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ host = "localhost"
 port = 3306
 password = "password"
 database = "foo"
+name = "mysql Foo DB"
 
 [[conn]]
 type = "postgres"
@@ -151,6 +152,7 @@ user = "root"
 host = "localhost"
 port = 5432
 database = "bar"
+name = "postgres Bar DB"
 
 [[conn]]
 type = "sqlite"


### PR DESCRIPTION
hi, thought it would be worth using `name` in a couple of the example config fields

This would require a new release though, since the [latest release](https://github.com/TaKO8Ki/gobang/tree/v0.1.0-alpha.5) predates #105 

Thanks for the cool project :)

changelog: document name config field
