### PR TITLE
Adds a total row count in the footer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,3 +45,8 @@ which = "4.1"
 
 [dev-dependencies]
 pretty_assertions = "1.0.0"
+
+[profile.release]
+strip = true
+lto = true
+opt-level = 3

--- a/database-tree/src/databasetree.rs
+++ b/database-tree/src/databasetree.rs
@@ -1,9 +1,9 @@
+use std::{collections::BTreeSet, usize};
+
 use crate::{
     databasetreeitems::DatabaseTreeItems, error::Result, item::DatabaseTreeItemKind,
-    tree_iter::TreeIterator,
+    tree_iter::TreeIterator, Database, Table,
 };
-use crate::{Database, Table};
-use std::{collections::BTreeSet, usize};
 
 ///
 #[derive(Copy, Clone, Debug)]
@@ -366,8 +366,9 @@ impl DatabaseTree {
 
 #[cfg(test)]
 mod test {
-    use crate::{Database, DatabaseTree, MoveSelection, Schema, Table};
     use std::collections::BTreeSet;
+
+    use crate::{Database, DatabaseTree, MoveSelection, Schema, Table};
 
     impl Table {
         fn new(name: String) -> Self {

--- a/database-tree/src/databasetreeitems.rs
+++ b/database-tree/src/databasetreeitems.rs
@@ -1,9 +1,11 @@
-use crate::{error::Result, treeitems_iter::TreeItemsIterator};
-use crate::{item::DatabaseTreeItemKind, DatabaseTreeItem};
-use crate::{Child, Database};
 use std::{
     collections::{BTreeSet, HashMap},
     usize,
+};
+
+use crate::{
+    error::Result, item::DatabaseTreeItemKind, treeitems_iter::TreeItemsIterator, Child, Database,
+    DatabaseTreeItem,
 };
 
 #[derive(Default)]

--- a/database-tree/src/error.rs
+++ b/database-tree/src/error.rs
@@ -1,4 +1,5 @@
 use std::num::TryFromIntError;
+
 use thiserror::Error;
 
 #[derive(Error, Debug)]

--- a/database-tree/src/lib.rs
+++ b/database-tree/src/lib.rs
@@ -6,8 +6,7 @@ mod tree_iter;
 mod treeitems_iter;
 
 pub use crate::{
-    databasetree::DatabaseTree,
-    databasetree::MoveSelection,
+    databasetree::{DatabaseTree, MoveSelection},
     item::{DatabaseTreeItem, TreeItemInfo},
 };
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,21 +1,19 @@
-use crate::clipboard::copy_to_clipboard;
-use crate::components::{
-    CommandInfo, Component as _, DrawableComponent as _, EventState, StatefulDrawableComponent,
-};
-use crate::database::{MySqlPool, Pool, PostgresPool, SqlitePool, RECORDS_LIMIT_PER_PAGE};
-use crate::event::Key;
-use crate::{
-    components::tab::Tab,
-    components::{
-        command, ConnectionsComponent, DatabasesComponent, ErrorComponent, HelpComponent,
-        PropertiesComponent, RecordTableComponent, SqlEditorComponent, TabComponent,
-    },
-    config::Config,
-};
 use tui::{
     backend::Backend,
     layout::{Constraint, Direction, Layout, Rect},
     Frame,
+};
+
+use crate::{
+    clipboard::copy_to_clipboard,
+    components::{
+        command, tab::Tab, CommandInfo, Component as _, ConnectionsComponent, DatabasesComponent,
+        DrawableComponent as _, ErrorComponent, EventState, HelpComponent, PropertiesComponent,
+        RecordTableComponent, SqlEditorComponent, StatefulDrawableComponent, TabComponent,
+    },
+    config::Config,
+    database::{MySqlPool, Pool, PostgresPool, SqlitePool, RECORDS_LIMIT_PER_PAGE},
+    event::Key,
 };
 
 pub enum Focus {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,6 @@
-use crate::config::CliConfig;
 use structopt::StructOpt;
+
+use crate::config::CliConfig;
 
 /// A cross-platform TUI database management tool written in Rust
 #[derive(StructOpt, Debug)]

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -1,8 +1,11 @@
-use anyhow::{anyhow, Result};
 #[cfg(all(target_family = "unix", not(target_os = "macos")))]
 use std::ffi::OsStr;
-use std::io::Write;
-use std::process::{Command, Stdio};
+use std::{
+    io::Write,
+    process::{Command, Stdio},
+};
+
+use anyhow::{anyhow, Result};
 
 fn execute_copy_command(command: Command, text: &str) -> Result<()> {
     let mut command = command;
@@ -42,6 +45,7 @@ fn gen_command(path: impl AsRef<OsStr>, xclip_syntax: bool) -> Command {
 #[cfg(all(target_family = "unix", not(target_os = "macos")))]
 pub fn copy_to_clipboard(string: &str) -> Result<()> {
     use std::path::PathBuf;
+
     use which::which;
     let (path, xclip_syntax) = which("xclip").ok().map_or_else(
         || {

--- a/src/components/completion.rs
+++ b/src/components/completion.rs
@@ -1,7 +1,3 @@
-use super::{Component, EventState, MovableComponent};
-use crate::components::command::CommandInfo;
-use crate::config::KeyConfig;
-use crate::event::Key;
 use anyhow::Result;
 use tui::{
     backend::Backend,
@@ -10,6 +6,9 @@ use tui::{
     widgets::{Block, Borders, Clear, List, ListItem, ListState},
     Frame,
 };
+
+use super::{Component, EventState, MovableComponent};
+use crate::{components::command::CommandInfo, config::KeyConfig, event::Key};
 
 const RESERVED_WORDS_IN_WHERE_CLAUSE: &[&str] = &["IN", "AND", "OR", "NOT", "NULL", "IS"];
 const ALL_RESERVED_WORDS: &[&str] = &[

--- a/src/components/connections.rs
+++ b/src/components/connections.rs
@@ -1,7 +1,3 @@
-use super::{Component, EventState, StatefulDrawableComponent};
-use crate::components::command::CommandInfo;
-use crate::config::{Connection, KeyConfig};
-use crate::event::Key;
 use anyhow::Result;
 use tui::{
     backend::Backend,
@@ -10,6 +6,13 @@ use tui::{
     text::{Span, Spans},
     widgets::{Block, Borders, Clear, List, ListItem, ListState},
     Frame,
+};
+
+use super::{Component, EventState, StatefulDrawableComponent};
+use crate::{
+    components::command::CommandInfo,
+    config::{Connection, KeyConfig},
+    event::Key,
 };
 
 pub struct ConnectionsComponent {

--- a/src/components/database_filter.rs
+++ b/src/components/database_filter.rs
@@ -1,6 +1,3 @@
-use super::{compute_character_width, Component, DrawableComponent, EventState};
-use crate::components::command::CommandInfo;
-use crate::event::Key;
 use anyhow::Result;
 use database_tree::Table;
 use tui::{
@@ -12,6 +9,9 @@ use tui::{
     Frame,
 };
 use unicode_width::UnicodeWidthStr;
+
+use super::{compute_character_width, Component, DrawableComponent, EventState};
+use crate::{components::command::CommandInfo, event::Key};
 
 pub struct DatabaseFilterComponent {
     pub table: Option<Table>,

--- a/src/components/databases.rs
+++ b/src/components/databases.rs
@@ -1,17 +1,7 @@
-use super::{
-    utils::scroll_vertical::VerticalScroll, Component, DatabaseFilterComponent, DrawableComponent,
-    EventState,
-};
-use crate::components::command::{self, CommandInfo};
-use crate::config::{Connection, KeyConfig};
-use crate::database::Pool;
-use crate::event::Key;
-use crate::ui::common_nav;
-use crate::ui::scrolllist::draw_list_block;
+use std::{collections::BTreeSet, convert::From};
+
 use anyhow::Result;
 use database_tree::{Database, DatabaseTree, DatabaseTreeItem};
-use std::collections::BTreeSet;
-use std::convert::From;
 use tui::{
     backend::Backend,
     layout::{Constraint, Direction, Layout, Rect},
@@ -19,6 +9,18 @@ use tui::{
     text::{Span, Spans},
     widgets::{Block, Borders},
     Frame,
+};
+
+use super::{
+    utils::scroll_vertical::VerticalScroll, Component, DatabaseFilterComponent, DrawableComponent,
+    EventState,
+};
+use crate::{
+    components::command::{self, CommandInfo},
+    config::{Connection, KeyConfig},
+    database::Pool,
+    event::Key,
+    ui::{common_nav, scrolllist::draw_list_block},
 };
 
 // ▸
@@ -274,8 +276,9 @@ fn tree_nav(tree: &mut DatabaseTree, key: Key, key_config: &KeyConfig) -> bool {
 
 #[cfg(test)]
 mod test {
-    use super::{Color, Database, DatabaseTreeItem, DatabasesComponent, Span, Spans, Style};
     use database_tree::Table;
+
+    use super::{Color, Database, DatabaseTreeItem, DatabasesComponent, Span, Spans, Style};
 
     #[test]
     fn test_tree_database_tree_item_to_span() {

--- a/src/components/debug.rs
+++ b/src/components/debug.rs
@@ -1,7 +1,3 @@
-use super::{Component, DrawableComponent, EventState};
-use crate::components::command::CommandInfo;
-use crate::config::KeyConfig;
-use crate::event::Key;
 use anyhow::Result;
 use tui::{
     backend::Backend,
@@ -9,6 +5,9 @@ use tui::{
     widgets::{Block, Borders, Clear, Paragraph, Wrap},
     Frame,
 };
+
+use super::{Component, DrawableComponent, EventState};
+use crate::{components::command::CommandInfo, config::KeyConfig, event::Key};
 
 pub struct DebugComponent {
     msg: String,

--- a/src/components/error.rs
+++ b/src/components/error.rs
@@ -1,7 +1,3 @@
-use super::{Component, DrawableComponent, EventState};
-use crate::components::command::CommandInfo;
-use crate::config::KeyConfig;
-use crate::event::Key;
 use anyhow::Result;
 use tui::{
     backend::Backend,
@@ -10,6 +6,9 @@ use tui::{
     widgets::{Block, Borders, Clear, Paragraph, Wrap},
     Frame,
 };
+
+use super::{Component, DrawableComponent, EventState};
+use crate::{components::command::CommandInfo, config::KeyConfig, event::Key};
 
 pub struct ErrorComponent {
     pub error: String,

--- a/src/components/help.rs
+++ b/src/components/help.rs
@@ -1,11 +1,7 @@
-use super::{Component, DrawableComponent, EventState};
-use crate::components::command::CommandInfo;
-use crate::config::KeyConfig;
-use crate::event::Key;
-use crate::version::Version;
+use std::convert::From;
+
 use anyhow::Result;
 use itertools::Itertools;
-use std::convert::From;
 use tui::{
     backend::Backend,
     layout::{Alignment, Constraint, Direction, Layout, Rect},
@@ -14,6 +10,9 @@ use tui::{
     widgets::{Block, BorderType, Borders, Clear, Paragraph},
     Frame,
 };
+
+use super::{Component, DrawableComponent, EventState};
+use crate::{components::command::CommandInfo, config::KeyConfig, event::Key, version::Version};
 
 pub struct HelpComponent {
     cmds: Vec<CommandInfo>,

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -18,11 +18,17 @@ pub mod utils;
 #[cfg(debug_assertions)]
 pub mod debug;
 
+use std::convert::TryInto;
+
+use anyhow::Result;
+use async_trait::async_trait;
 pub use command::{CommandInfo, CommandText};
 pub use completion::CompletionComponent;
 pub use connections::ConnectionsComponent;
 pub use database_filter::DatabaseFilterComponent;
 pub use databases::DatabasesComponent;
+#[cfg(debug_assertions)]
+pub use debug::DebugComponent;
 pub use error::ErrorComponent;
 pub use help::HelpComponent;
 pub use properties::PropertiesComponent;
@@ -33,16 +39,10 @@ pub use table::TableComponent;
 pub use table_filter::TableFilterComponent;
 pub use table_status::TableStatusComponent;
 pub use table_value::TableValueComponent;
-
-#[cfg(debug_assertions)]
-pub use debug::DebugComponent;
-
-use crate::database::Pool;
-use anyhow::Result;
-use async_trait::async_trait;
-use std::convert::TryInto;
 use tui::{backend::Backend, layout::Rect, Frame};
 use unicode_width::UnicodeWidthChar;
+
+use crate::database::Pool;
 
 #[derive(PartialEq, Debug)]
 pub enum EventState {

--- a/src/components/properties.rs
+++ b/src/components/properties.rs
@@ -1,10 +1,3 @@
-use super::{Component, EventState, StatefulDrawableComponent};
-use crate::clipboard::copy_to_clipboard;
-use crate::components::command::{self, CommandInfo};
-use crate::components::TableComponent;
-use crate::config::KeyConfig;
-use crate::database::Pool;
-use crate::event::Key;
 use anyhow::Result;
 use async_trait::async_trait;
 use database_tree::{Database, Table};
@@ -14,6 +7,18 @@ use tui::{
     style::{Color, Style},
     widgets::{Block, Borders, List, ListItem},
     Frame,
+};
+
+use super::{Component, EventState, StatefulDrawableComponent};
+use crate::{
+    clipboard::copy_to_clipboard,
+    components::{
+        command::{self, CommandInfo},
+        TableComponent,
+    },
+    config::KeyConfig,
+    database::Pool,
+    event::Key,
 };
 
 #[derive(Debug, PartialEq)]

--- a/src/components/properties.rs
+++ b/src/components/properties.rs
@@ -74,6 +74,7 @@ impl PropertiesComponent {
                     .iter()
                     .map(|c| c.columns())
                     .collect::<Vec<Vec<String>>>(),
+                Some(columns.len()),
                 columns.get(0).unwrap().fields(),
                 database.clone(),
                 table.clone(),
@@ -87,6 +88,7 @@ impl PropertiesComponent {
                     .iter()
                     .map(|c| c.columns())
                     .collect::<Vec<Vec<String>>>(),
+                Some(constraints.len()),
                 constraints.get(0).unwrap().fields(),
                 database.clone(),
                 table.clone(),
@@ -100,6 +102,7 @@ impl PropertiesComponent {
                     .iter()
                     .map(|c| c.columns())
                     .collect::<Vec<Vec<String>>>(),
+                Some(foreign_keys.len()),
                 foreign_keys.get(0).unwrap().fields(),
                 database.clone(),
                 table.clone(),
@@ -113,6 +116,7 @@ impl PropertiesComponent {
                     .iter()
                     .map(|c| c.columns())
                     .collect::<Vec<Vec<String>>>(),
+                Some(indexes.len()),
                 indexes.get(0).unwrap().fields(),
                 database.clone(),
                 table.clone(),

--- a/src/components/record_table.rs
+++ b/src/components/record_table.rs
@@ -36,11 +36,13 @@ impl RecordTableComponent {
     pub fn update(
         &mut self,
         rows: Vec<Vec<String>>,
+        total_rows: usize,
         headers: Vec<String>,
         database: Database,
         table: DTable,
     ) {
-        self.table.update(rows, headers, database, table.clone());
+        self.table
+            .update(rows, Some(total_rows), headers, database, table.clone());
         self.filter.table = Some(table);
     }
 

--- a/src/components/record_table.rs
+++ b/src/components/record_table.rs
@@ -1,14 +1,16 @@
-use super::{Component, EventState, StatefulDrawableComponent};
-use crate::components::command::CommandInfo;
-use crate::components::{TableComponent, TableFilterComponent};
-use crate::config::KeyConfig;
-use crate::event::Key;
 use anyhow::Result;
 use database_tree::{Database, Table as DTable};
 use tui::{
     backend::Backend,
     layout::{Constraint, Direction, Layout, Rect},
     Frame,
+};
+
+use super::{Component, EventState, StatefulDrawableComponent};
+use crate::{
+    components::{command::CommandInfo, TableComponent, TableFilterComponent},
+    config::KeyConfig,
+    event::Key,
 };
 
 pub enum Focus {

--- a/src/components/sql_editor.rs
+++ b/src/components/sql_editor.rs
@@ -269,8 +269,9 @@ impl Component for SqlEditorComponent {
                     database,
                     table,
                 } => {
-                    // TODO
-                    self.table.update(rows, None, headers, database, table);
+                    let total_rows = rows.len();
+                    self.table
+                        .update(rows, Some(total_rows), headers, database, table);
                     self.focus = Focus::Table;
                     self.query_result = None;
                 }

--- a/src/components/sql_editor.rs
+++ b/src/components/sql_editor.rs
@@ -269,7 +269,8 @@ impl Component for SqlEditorComponent {
                     database,
                     table,
                 } => {
-                    self.table.update(rows, headers, database, table);
+                    // TODO
+                    self.table.update(rows, None, headers, database, table);
                     self.focus = Focus::Table;
                     self.query_result = None;
                 }

--- a/src/components/sql_editor.rs
+++ b/src/components/sql_editor.rs
@@ -1,12 +1,3 @@
-use super::{
-    compute_character_width, CompletionComponent, Component, EventState, MovableComponent,
-    StatefulDrawableComponent, TableComponent,
-};
-use crate::components::command::CommandInfo;
-use crate::config::KeyConfig;
-use crate::database::{ExecuteResult, Pool};
-use crate::event::Key;
-use crate::ui::stateful_paragraph::{ParagraphState, StatefulParagraph};
 use anyhow::Result;
 use async_trait::async_trait;
 use tui::{
@@ -17,6 +8,18 @@ use tui::{
     Frame,
 };
 use unicode_width::UnicodeWidthStr;
+
+use super::{
+    compute_character_width, CompletionComponent, Component, EventState, MovableComponent,
+    StatefulDrawableComponent, TableComponent,
+};
+use crate::{
+    components::command::CommandInfo,
+    config::KeyConfig,
+    database::{ExecuteResult, Pool},
+    event::Key,
+    ui::stateful_paragraph::{ParagraphState, StatefulParagraph},
+};
 
 struct QueryResult {
     updated_rows: u64,

--- a/src/components/tab.rs
+++ b/src/components/tab.rs
@@ -1,7 +1,3 @@
-use super::{Component, DrawableComponent, EventState};
-use crate::components::command::{self, CommandInfo};
-use crate::config::KeyConfig;
-use crate::event::Key;
 use anyhow::Result;
 use strum_macros::EnumIter;
 use tui::{
@@ -11,6 +7,13 @@ use tui::{
     text::Spans,
     widgets::{Block, Borders, Tabs},
     Frame,
+};
+
+use super::{Component, DrawableComponent, EventState};
+use crate::{
+    components::command::{self, CommandInfo},
+    config::KeyConfig,
+    event::Key,
 };
 
 #[derive(Debug, Clone, Copy, EnumIter)]

--- a/src/components/table.rs
+++ b/src/components/table.rs
@@ -1,13 +1,7 @@
-use super::{
-    utils::scroll_vertical::VerticalScroll, Component, DrawableComponent, EventState,
-    StatefulDrawableComponent, TableStatusComponent, TableValueComponent,
-};
-use crate::components::command::{self, CommandInfo};
-use crate::config::KeyConfig;
-use crate::event::Key;
+use std::convert::From;
+
 use anyhow::Result;
 use database_tree::{Database, Table as DTable};
-use std::convert::From;
 use tui::{
     backend::Backend,
     layout::{Constraint, Direction, Layout, Rect},
@@ -16,6 +10,16 @@ use tui::{
     Frame,
 };
 use unicode_width::UnicodeWidthStr;
+
+use super::{
+    utils::scroll_vertical::VerticalScroll, Component, DrawableComponent, EventState,
+    StatefulDrawableComponent, TableStatusComponent, TableValueComponent,
+};
+use crate::{
+    components::command::{self, CommandInfo},
+    config::KeyConfig,
+    event::Key,
+};
 
 pub struct TableComponent {
     pub headers: Vec<String>,
@@ -573,8 +577,9 @@ impl Component for TableComponent {
 
 #[cfg(test)]
 mod test {
-    use super::{KeyConfig, TableComponent};
     use tui::layout::Constraint;
+
+    use super::{KeyConfig, TableComponent};
 
     #[test]
     fn test_headers() {

--- a/src/components/table.rs
+++ b/src/components/table.rs
@@ -20,6 +20,7 @@ use unicode_width::UnicodeWidthStr;
 pub struct TableComponent {
     pub headers: Vec<String>,
     pub rows: Vec<Vec<String>>,
+    pub total_rows: Option<usize>,
     pub eod: bool,
     pub selected_row: TableState,
     table: Option<(Database, DTable)>,
@@ -36,6 +37,7 @@ impl TableComponent {
             selected_row: TableState::default(),
             headers: vec![],
             rows: vec![],
+            total_rows: None,
             table: None,
             selected_column: 0,
             selection_area_corner: None,
@@ -55,6 +57,7 @@ impl TableComponent {
     pub fn update(
         &mut self,
         rows: Vec<Vec<String>>,
+        total_rows: Option<usize>,
         headers: Vec<String>,
         database: Database,
         table: DTable,
@@ -65,6 +68,7 @@ impl TableComponent {
         }
         self.headers = headers;
         self.rows = rows;
+        self.total_rows = total_rows;
         self.selected_column = 0;
         self.selection_area_corner = None;
         self.column_page_start = std::cell::Cell::new(0);
@@ -503,6 +507,7 @@ impl StatefulDrawableComponent for TableComponent {
             } else {
                 Some(self.rows.len())
             },
+            self.total_rows,
             if self.headers.is_empty() {
                 None
             } else {

--- a/src/components/table_filter.rs
+++ b/src/components/table_filter.rs
@@ -1,10 +1,3 @@
-use super::{
-    compute_character_width, CompletionComponent, Component, EventState, MovableComponent,
-    StatefulDrawableComponent,
-};
-use crate::components::command::CommandInfo;
-use crate::config::KeyConfig;
-use crate::event::Key;
 use anyhow::Result;
 use database_tree::Table;
 use tui::{
@@ -16,6 +9,12 @@ use tui::{
     Frame,
 };
 use unicode_width::UnicodeWidthStr;
+
+use super::{
+    compute_character_width, CompletionComponent, Component, EventState, MovableComponent,
+    StatefulDrawableComponent,
+};
+use crate::{components::command::CommandInfo, config::KeyConfig, event::Key};
 
 pub struct TableFilterComponent {
     key_config: KeyConfig,

--- a/src/components/table_status.rs
+++ b/src/components/table_status.rs
@@ -15,6 +15,7 @@ use tui::{
 pub struct TableStatusComponent {
     column_count: Option<usize>,
     row_count: Option<usize>,
+    total_row_count: Option<usize>,
     table: Option<Table>,
 }
 
@@ -22,6 +23,7 @@ impl Default for TableStatusComponent {
     fn default() -> Self {
         Self {
             row_count: None,
+            total_row_count: None,
             column_count: None,
             table: None,
         }
@@ -31,11 +33,13 @@ impl Default for TableStatusComponent {
 impl TableStatusComponent {
     pub fn new(
         row_count: Option<usize>,
+        total_row_count: Option<usize>,
         column_count: Option<usize>,
         table: Option<Table>,
     ) -> Self {
         Self {
             row_count,
+            total_row_count,
             column_count,
             table,
         }
@@ -48,6 +52,11 @@ impl DrawableComponent for TableStatusComponent {
             Span::from(format!(
                 "rows: {}, ",
                 self.row_count.map_or("-".to_string(), |c| c.to_string())
+            )),
+            Span::from(format!(
+                "total rows : {}, ",
+                self.total_row_count
+                    .map_or("-".to_string(), |c| c.to_string())
             )),
             Span::from(format!(
                 "columns: {}, ",

--- a/src/components/table_status.rs
+++ b/src/components/table_status.rs
@@ -1,6 +1,3 @@
-use super::{Component, DrawableComponent, EventState};
-use crate::components::command::CommandInfo;
-use crate::event::Key;
 use anyhow::Result;
 use database_tree::Table;
 use tui::{
@@ -11,6 +8,9 @@ use tui::{
     widgets::{Block, Borders, Paragraph},
     Frame,
 };
+
+use super::{Component, DrawableComponent, EventState};
+use crate::{components::command::CommandInfo, event::Key};
 
 pub struct TableStatusComponent {
     column_count: Option<usize>,

--- a/src/components/table_value.rs
+++ b/src/components/table_value.rs
@@ -1,6 +1,3 @@
-use super::{Component, DrawableComponent, EventState};
-use crate::components::command::CommandInfo;
-use crate::event::Key;
 use anyhow::Result;
 use tui::{
     backend::Backend,
@@ -9,6 +6,9 @@ use tui::{
     widgets::{Block, Borders, Paragraph},
     Frame,
 };
+
+use super::{Component, DrawableComponent, EventState};
+use crate::{components::command::CommandInfo, event::Key};
 
 pub struct TableValueComponent {
     value: String,

--- a/src/components/utils/scroll_vertical.rs
+++ b/src/components/utils/scroll_vertical.rs
@@ -1,6 +1,8 @@
-use crate::ui::scrollbar::draw_scrollbar;
 use std::cell::Cell;
+
 use tui::{backend::Backend, layout::Rect, Frame};
+
+use crate::ui::scrollbar::draw_scrollbar;
 
 pub struct VerticalScroll {
     top: Cell<usize>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,14 +1,16 @@
-use crate::log::LogLevel;
-use crate::Key;
-use serde::Deserialize;
-use std::fmt;
-use std::fs::File;
-use std::io::{BufReader, Read};
-use std::path::{Path, PathBuf};
-use structopt::StructOpt;
+use std::{
+    fmt,
+    fs::File,
+    io::{BufReader, Read},
+    path::{Path, PathBuf},
+};
 
+use serde::Deserialize;
 #[cfg(test)]
 use serde::Serialize;
+use structopt::StructOpt;
+
+use crate::{log::LogLevel, Key};
 
 #[derive(StructOpt, Debug)]
 pub struct CliConfig {
@@ -325,9 +327,11 @@ fn expand_path(path: &Path) -> Option<PathBuf> {
 
 #[cfg(test)]
 mod test {
-    use super::{expand_path, KeyConfig, Path, PathBuf};
-    use serde_json::Value;
     use std::env;
+
+    use serde_json::Value;
+
+    use super::{expand_path, KeyConfig, Path, PathBuf};
 
     #[test]
     fn test_overlappted_key() {

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -23,6 +23,15 @@ pub trait Pool: Send + Sync {
         page: u16,
         filter: Option<String>,
     ) -> anyhow::Result<(Vec<String>, Vec<Vec<String>>)>;
+
+    /// Get the total number of records in a table
+    async fn get_total_records_count(
+        &self,
+        database: &Database,
+        table: &Table,
+        filter: Option<String>,
+    ) -> anyhow::Result<usize>;
+
     async fn get_columns(
         &self,
         database: &Database,

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -2,12 +2,11 @@ pub mod mysql;
 pub mod postgres;
 pub mod sqlite;
 
+use async_trait::async_trait;
+use database_tree::{Child, Database, Table};
 pub use mysql::MySqlPool;
 pub use postgres::PostgresPool;
 pub use sqlite::SqlitePool;
-
-use async_trait::async_trait;
-use database_tree::{Child, Database, Table};
 
 pub const RECORDS_LIMIT_PER_PAGE: u8 = 200;
 

--- a/src/database/mysql.rs
+++ b/src/database/mysql.rs
@@ -1,13 +1,16 @@
-use crate::get_or_null;
+use std::time::Duration;
 
-use super::{ExecuteResult, Pool, TableRow, RECORDS_LIMIT_PER_PAGE};
 use async_trait::async_trait;
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 use database_tree::{Child, Database, Table};
 use futures::TryStreamExt;
-use sqlx::mysql::{MySqlColumn, MySqlPoolOptions, MySqlRow};
-use sqlx::{Column as _, Row as _, TypeInfo as _};
-use std::time::Duration;
+use sqlx::{
+    mysql::{MySqlColumn, MySqlPoolOptions, MySqlRow},
+    Column as _, Row as _, TypeInfo as _,
+};
+
+use super::{ExecuteResult, Pool, TableRow, RECORDS_LIMIT_PER_PAGE};
+use crate::get_or_null;
 
 pub struct MySqlPool {
     pool: sqlx::mysql::MySqlPool,

--- a/src/database/mysql.rs
+++ b/src/database/mysql.rs
@@ -265,6 +265,27 @@ impl Pool for MySqlPool {
         Ok((headers, records))
     }
 
+    async fn get_total_records_count(
+        &self,
+        _database: &Database,
+        table: &Table,
+        filter: Option<String>,
+    ) -> anyhow::Result<usize> {
+        let query = if let Some(filter) = filter {
+            format!(
+                "SELECT count(*) FROM `{table}` WHERE {filter}",
+                table = table.name,
+                filter = filter
+            )
+        } else {
+            format!("SELECT count(*) FROM `{}`", table.name)
+        };
+
+        let res = sqlx::query(query.as_str()).fetch_one(&self.pool).await?;
+
+        Ok(res.get::<i32, usize>(0) as usize)
+    }
+
     async fn get_columns(
         &self,
         database: &Database,

--- a/src/database/postgres.rs
+++ b/src/database/postgres.rs
@@ -326,17 +326,17 @@ impl Pool for PostgresPool {
     ) -> anyhow::Result<usize> {
         let query = if let Some(filter) = filter {
             format!(
-                "SELECT count(*) FROM `{table}` WHERE {filter}",
+                r#"SELECT count(*) FROM "{table}" WHERE {filter}"#,
                 table = table.name,
                 filter = filter
             )
         } else {
-            format!("SELECT count(*) FROM `{}`", table.name)
+            format!(r#"SELECT count(*) FROM "{}""#, table.name)
         };
 
         let res = sqlx::query(query.as_str()).fetch_one(&self.pool).await?;
 
-        Ok(res.get::<i32, usize>(0) as usize)
+        Ok(res.get::<i64, usize>(0) as usize)
     }
 
     async fn get_columns(

--- a/src/database/postgres.rs
+++ b/src/database/postgres.rs
@@ -318,6 +318,27 @@ impl Pool for PostgresPool {
         Ok((headers, records))
     }
 
+    async fn get_total_records_count(
+        &self,
+        _database: &Database,
+        table: &Table,
+        filter: Option<String>,
+    ) -> anyhow::Result<usize> {
+        let query = if let Some(filter) = filter {
+            format!(
+                "SELECT count(*) FROM `{table}` WHERE {filter}",
+                table = table.name,
+                filter = filter
+            )
+        } else {
+            format!("SELECT count(*) FROM `{}`", table.name)
+        };
+
+        let res = sqlx::query(query.as_str()).fetch_one(&self.pool).await?;
+
+        Ok(res.get::<i32, usize>(0) as usize)
+    }
+
     async fn get_columns(
         &self,
         database: &Database,

--- a/src/database/postgres.rs
+++ b/src/database/postgres.rs
@@ -1,14 +1,17 @@
-use crate::get_or_null;
+use std::time::Duration;
 
-use super::{ExecuteResult, Pool, TableRow, RECORDS_LIMIT_PER_PAGE};
 use async_trait::async_trait;
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 use database_tree::{Child, Database, Schema, Table};
 use futures::TryStreamExt;
 use itertools::Itertools;
-use sqlx::postgres::{PgColumn, PgPool, PgPoolOptions, PgRow};
-use sqlx::{Column as _, Row as _, TypeInfo as _};
-use std::time::Duration;
+use sqlx::{
+    postgres::{PgColumn, PgPool, PgPoolOptions, PgRow},
+    Column as _, Row as _, TypeInfo as _,
+};
+
+use super::{ExecuteResult, Pool, TableRow, RECORDS_LIMIT_PER_PAGE};
+use crate::get_or_null;
 
 pub struct PostgresPool {
     pool: PgPool,

--- a/src/database/sqlite.rs
+++ b/src/database/sqlite.rs
@@ -1,13 +1,16 @@
-use crate::get_or_null;
+use std::time::Duration;
 
-use super::{ExecuteResult, Pool, TableRow, RECORDS_LIMIT_PER_PAGE};
 use async_trait::async_trait;
 use chrono::NaiveDateTime;
 use database_tree::{Child, Database, Table};
 use futures::TryStreamExt;
-use sqlx::sqlite::{SqliteColumn, SqlitePoolOptions, SqliteRow};
-use sqlx::{Column as _, Row as _, TypeInfo as _};
-use std::time::Duration;
+use sqlx::{
+    sqlite::{SqliteColumn, SqlitePoolOptions, SqliteRow},
+    Column as _, Row as _, TypeInfo as _,
+};
+
+use super::{ExecuteResult, Pool, TableRow, RECORDS_LIMIT_PER_PAGE};
+use crate::get_or_null;
 
 pub struct SqlitePool {
     pool: sqlx::sqlite::SqlitePool,

--- a/src/database/sqlite.rs
+++ b/src/database/sqlite.rs
@@ -265,6 +265,27 @@ impl Pool for SqlitePool {
         Ok((headers, records))
     }
 
+    async fn get_total_records_count(
+        &self,
+        _database: &Database,
+        table: &Table,
+        filter: Option<String>,
+    ) -> anyhow::Result<usize> {
+        let query = if let Some(filter) = filter {
+            format!(
+                "SELECT count(*) FROM `{table}` WHERE {filter}",
+                table = table.name,
+                filter = filter
+            )
+        } else {
+            format!("SELECT count(*) FROM `{}`", table.name)
+        };
+
+        let res = sqlx::query(query.as_str()).fetch_one(&self.pool).await?;
+
+        Ok(res.get::<i32, usize>(0) as usize)
+    }
+
     async fn get_columns(
         &self,
         _database: &Database,

--- a/src/event/events.rs
+++ b/src/event/events.rs
@@ -1,6 +1,8 @@
-use crate::event::Key;
-use crossterm::event;
 use std::{sync::mpsc, thread, time::Duration};
+
+use crossterm::event;
+
+use crate::event::Key;
 
 #[derive(Debug, Clone, Copy)]
 pub struct EventConfig {

--- a/src/event/key.rs
+++ b/src/event/key.rs
@@ -1,7 +1,7 @@
-use crossterm::event;
-use serde::Deserialize;
 use std::fmt;
 
+use crossterm::event;
+use serde::Deserialize;
 #[cfg(test)]
 use serde::Serialize;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,15 +11,19 @@ mod version;
 #[macro_use]
 mod log;
 
-use crate::app::App;
-use crate::event::{Event, Key};
+use std::io;
+
 use anyhow::Result;
 use crossterm::{
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
     ExecutableCommand,
 };
-use std::io;
 use tui::{backend::CrosstermBackend, Terminal};
+
+use crate::{
+    app::App,
+    event::{Event, Key},
+};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,6 +1,6 @@
-use crate::config::KeyConfig;
-use crate::event::Key;
 use database_tree::MoveSelection;
+
+use crate::{config::KeyConfig, event::Key};
 
 pub mod reflow;
 pub mod scrollbar;

--- a/src/ui/reflow.rs
+++ b/src/ui/reflow.rs
@@ -227,8 +227,9 @@ fn trim_offset(src: &str, mut offset: usize) -> &str {
 
 #[cfg(test)]
 mod test {
-    use super::*;
     use unicode_segmentation::UnicodeSegmentation;
+
+    use super::*;
 
     enum Composer {
         WordWrapper { trim: bool },
@@ -473,7 +474,8 @@ mod test {
         // to test double-width chars.
         // You are more than welcome to add word boundary detection based of alterations of
         // hiragana and katakana...
-        // This happens to also be a test case for mixed width because regular spaces are single width.
+        // This happens to also be a test case for mixed width because regular spaces are single
+        // width.
         let text = "コンピュ ータ上で文字を扱う場合、 典型的には文 字による 通信を行 う場合にその両端点では、";
         let (word_wrapper, word_wrapper_width) =
             run_composer(Composer::WordWrapper { trim: true }, text, width);

--- a/src/ui/scrollbar.rs
+++ b/src/ui/scrollbar.rs
@@ -1,5 +1,6 @@
-use easy_cast::CastFloat;
 use std::convert::TryFrom;
+
+use easy_cast::CastFloat;
 use tui::{
     backend::Backend,
     buffer::Buffer,

--- a/src/ui/scrolllist.rs
+++ b/src/ui/scrolllist.rs
@@ -1,4 +1,5 @@
 use std::iter::Iterator;
+
 use tui::{
     backend::Backend,
     buffer::Buffer,

--- a/src/ui/stateful_paragraph.rs
+++ b/src/ui/stateful_paragraph.rs
@@ -1,7 +1,8 @@
 #![allow(dead_code)]
 
-use easy_cast::Cast;
 use std::iter;
+
+use easy_cast::Cast;
 use tui::{
     buffer::Buffer,
     layout::{Alignment, Rect},

--- a/src/ui/syntax_text.rs
+++ b/src/ui/syntax_text.rs
@@ -1,4 +1,5 @@
 use std::ops::Range;
+
 use syntect::{
     highlighting::{
         FontStyle, HighlightState, Highlighter, RangedHighlightIterator, Style, ThemeSet,


### PR DESCRIPTION
# Checklist

- [ ] Added passing unit tests
- [x] `cargo test` passes locally. It takes much time.
- [x] Run `cargo fmt`

# Description
This PR adds a _total rows_ field in the properties. This is especially useful for large databases, it prevents the need to write an entire request just to know the total count.

This fixes #106.

**NOTE:** I didn't implemented tests mainly because it didn't find anything useful to test. Would be glad to add some though if you indicate what to test.

## Example :
![image](https://user-images.githubusercontent.com/36198422/234198885-b4cdf374-bb2a-4936-86be-bf3a50d9c1ef.png)

# Changelog
- Adds a total rows count in the footer
