### PR TITLE
chore: optimized release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,3 +45,8 @@ which = "4.1"
 
 [dev-dependencies]
 pretty_assertions = "1.0.0"
+
+[profile.release]
+strip = true
+lto = true
+opt-level = 3


### PR DESCRIPTION
# Description

I think gobang could benefit release optimizations.
By stripping  debug symbols and asking the compiler for optimizations the size is reduced by almost one third! (at least on my machine, linux 64bits).

![image](https://user-images.githubusercontent.com/36198422/234230640-66684ff0-8323-44d2-a2e5-023ba90837af.png) => ![image](https://user-images.githubusercontent.com/36198422/234238987-526f0f46-c731-47a8-971e-7244b157d136.png)

# changelog:
- Optimized code & size for release